### PR TITLE
Fix Invalid URL for Nordigen API Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Create `index.html`
 <script src="./node_modules/nordigen-bank-ui/package/src/selector.js"></script>
 ```
 
-Next step is to fetch aspsp list from [Nordigen API](https://nordigen.com/en/docs/account-information/overview/parameters-and-responses/#/aspsps/retrieve%20all%20supported%20ASPSP(s)%20in%20a%20given%20country)
+Next step is to fetch aspsp list from [Nordigen API](https://nordigen.com/en/docs/account-information/integration/parameters-and-responses/#/institutions/retrieve%20all%20supported%20Institutions%20in%20a%20given%20country)
 
 ```javascript
 // Assume this is response from the API


### PR DESCRIPTION
Changed "https://nordigen.com/en/docs/account-information/overview/parameters-and-responses/#/aspsps/retrieve%20all%20supported%20ASPSP(s)%20in%20a%20given%20country" to "https://nordigen.com/en/docs/account-information/integration/parameters-and-responses/#/institutions/retrieve%20all%20supported%20Institutions%20in%20a%20given%20country"